### PR TITLE
Sync cohesion handoff with invalid-route navigability work

### DIFF
--- a/docs/handoff/2026-07-11-01-api-driven-cohesion.md
+++ b/docs/handoff/2026-07-11-01-api-driven-cohesion.md
@@ -1,6 +1,6 @@
 # API-driven cohesion cleanup handoff
 
-Checkpoint: 2026-07-11 12:28 PDT
+Checkpoint: 2026-07-11 12:58 PDT
 
 ## Start here
 
@@ -27,7 +27,10 @@ The intended starting state is a clean `main` worktree whose latest commits are:
 - `2d868ca` — specify the cleanup and compatibility matrix
 - `f81a9ac` — unify trip, inventory, and assignment mutations across REST and MCP
 - `9e0760d` — harden database paths, versioned migrations, foreign keys, test isolation, and dependency locks
-- the checkpoint commit containing this handoff — move trip and daily-plan projections behind `TripPlanningService`
+- `de7006b` — move trip and daily-plan projections behind `TripPlanningService`
+- `ee9ac40` — persist OAuth clients and rotate/hash refresh tokens
+- `05376b4` — make trip routes deep-linkable
+- the checkpoint commit containing this handoff (`f8232f3`) — keep invalid trip routes navigable
 
 ## What is now true
 
@@ -42,8 +45,8 @@ The intended starting state is a clean `main` worktree whose latest commits are:
 - Refresh tokens are stored only as SHA-256 hashes, rotate atomically on use, and
   cannot be replayed. Existing plaintext refresh-token rows migrate to hashes
   while preserving the next legitimate refresh exchange.
-- At this checkpoint the full backend suite passes 159 tests; frontend lint and
-  production build also pass.
+- At this checkpoint the full backend suite passes 159 tests and the frontend
+  harness passes 17 tests; frontend lint and production build also pass.
 
 Important implementation files:
 
@@ -90,8 +93,12 @@ The route/context divergence is fixed. Canonical trip URLs are:
 The route trip ID controls context, the selector preserves the current trip
 subroute, global pages retain selection without navigating away, legacy root and
 packing URLs redirect, invalid paths have stable boundaries, and stale responses
-cannot overwrite a newer route. The frontend harness covers these behaviors plus
-every global page and recipe new/edit deep link.
+cannot overwrite a newer route. Unknown trip IDs no longer hijack context: an
+unrecognized route trip does not become the active trip, the planner nav links
+and selector stay pointed at a valid trip so the app remains navigable, and
+selection recovers to a real trip if the current selection disappears from the
+list. The frontend harness covers these behaviors plus every global page and
+recipe new/edit deep link.
 
 ## Remaining frontend slice
 


### PR DESCRIPTION
## Summary

The API-driven cohesion handoff (`docs/handoff/2026-07-11-01-api-driven-cohesion.md`) was last written at commit `05376b4`, but the later commit `f8232f3` ("Keep invalid trip routes navigable") never got folded into it. This updates the handoff so the next agent picks up from an accurate checkpoint.

## Changes

- **Checkpoint timestamp** — `12:28 → 12:58 PDT` to match the actual HEAD commit time.
- **Starting-state commit list** — previously stopped at `de7006b`; now lists the real chain through HEAD (`de7006b` → `ee9ac40` OAuth → `05376b4` deep-linkable → `f8232f3` navigable).
- **Test counts** — added the frontend harness count (17 tests) alongside the existing backend 159.
- **"Frontend deep-linking completed" section** — documents the new guarantee: unknown trip IDs no longer hijack context; nav links and the selector stay pointed at a valid trip, and selection recovers if the current one disappears.

Docs-only change. The pending sections (OAuth/server boundaries, remaining frontend slice) are left intact since `f8232f3` did not touch that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0199Syde1TVdaYM7sSp3Zi94)_